### PR TITLE
fix: render mermaid wait_event labels with f-string event_type (#7)

### DIFF
--- a/edda/viewer_ui/components.py
+++ b/edda/viewer_ui/components.py
@@ -357,7 +357,9 @@ class HybridMermaidGenerator(MermaidGenerator):
                 if timeout:
                     label += f"<br/>timeout: {escape_mermaid_label(str(timeout))}s"
 
-                self.lines.append(f"    {node_id}{{{{{label}}}}}")
+                # Quoted hexagon form (id{{"label"}}): mermaid 11 rejects bare
+                # parens / colons inside unquoted hexagons.
+                self.lines.append(f'    {node_id}{{{{"{label}"}}}}')
                 self.lines.append(f"    {current_id} --> {node_id}")
                 wait_event_style = get_mermaid_style("waiting_event", self.is_dark)
                 self.lines.append(f"    style {node_id} {wait_event_style}")

--- a/edda/viewer_ui/components.py
+++ b/edda/viewer_ui/components.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from edda.viewer_ui.theme import get_edge_color, get_mermaid_node_style, get_mermaid_style
 from edda.visualizer.ast_analyzer import WorkflowAnalyzer
-from edda.visualizer.mermaid_generator import MermaidGenerator
+from edda.visualizer.mermaid_generator import MermaidGenerator, escape_mermaid_label
 
 
 def generate_interactive_mermaid(
@@ -350,12 +350,12 @@ class HybridMermaidGenerator(MermaidGenerator):
             elif step_type == "wait_event":
                 # Event waiting
                 node_id = self._next_node_id()
-                event_type = step.get("event_type", "unknown")
+                event_type = escape_mermaid_label(step.get("event_type", "unknown"))
                 timeout = step.get("timeout")
 
                 label = f"wait_event:<br/>{event_type}"
                 if timeout:
-                    label += f"<br/>timeout: {timeout}s"
+                    label += f"<br/>timeout: {escape_mermaid_label(str(timeout))}s"
 
                 self.lines.append(f"    {node_id}{{{{{label}}}}}")
                 self.lines.append(f"    {current_id} --> {node_id}")
@@ -406,21 +406,7 @@ class HybridMermaidGenerator(MermaidGenerator):
         """
         # Condition node (diamond shape)
         cond_id = self._next_node_id()
-        test_expr = condition.get("test", "condition")
-
-        # Sanitize test expression for Mermaid - remove ALL problematic characters
-        # Replace dict/list accessors and special chars
-        test_expr = (
-            test_expr.replace('"', "'")
-            .replace("{", "(")
-            .replace("}", ")")
-            .replace("[", ".")
-            .replace("]", "")
-            .replace("'", "")
-        )
-        # Limit length to avoid overflow
-        if len(test_expr) > 40:
-            test_expr = test_expr[:37] + "..."
+        test_expr = escape_mermaid_label(condition.get("test", "condition"), max_len=40)
 
         # Use diamond shape for condition - correct Mermaid syntax
         self.lines.append(f"    {cond_id}{{{test_expr}?}}")
@@ -777,19 +763,7 @@ class HybridMermaidGenerator(MermaidGenerator):
         """
         # Match node (diamond shape for the subject)
         match_id = self._next_node_id()
-        subject = match.get("subject", "value")
-
-        # Sanitize subject expression for Mermaid
-        subject = (
-            subject.replace('"', "'")
-            .replace("{", "(")
-            .replace("}", ")")
-            .replace("[", ".")
-            .replace("]", "")
-            .replace("'", "")
-        )
-        if len(subject) > 30:
-            subject = subject[:27] + "..."
+        subject = escape_mermaid_label(match.get("subject", "value"), max_len=30)
 
         self.lines.append(f"    {match_id}{{{{match {subject}}}}}")
         self.lines.append(f"    {prev_id} --> {match_id}")

--- a/edda/visualizer/mermaid_generator.py
+++ b/edda/visualizer/mermaid_generator.py
@@ -127,7 +127,9 @@ class MermaidGenerator:
                 if timeout:
                     label += f"<br/>timeout: {escape_mermaid_label(str(timeout))}s"
 
-                self.lines.append(f"    {node_id}{{{{{label}}}}}")
+                # Quoted hexagon form (id{{"label"}}): mermaid 11 rejects bare
+                # parens / colons inside unquoted hexagons.
+                self.lines.append(f'    {node_id}{{{{"{label}"}}}}')
                 self.lines.append(f"    {current_id} --> {node_id}")
                 self.lines.append(f"    style {node_id} fill:#fff4e6")
                 current_id = node_id

--- a/edda/visualizer/mermaid_generator.py
+++ b/edda/visualizer/mermaid_generator.py
@@ -8,6 +8,30 @@ extracted by the AST analyzer.
 from typing import Any
 
 
+def escape_mermaid_label(text: str, max_len: int = 60) -> str:
+    """Escape characters that break Mermaid node label syntax.
+
+    Replaces braces (which clash with hexagon `{{...}}` and diamond `{...}`
+    shape syntax), brackets, and quotes. Truncates overly long labels.
+
+    Used by both the base ``MermaidGenerator`` and the hybrid generator in
+    ``edda.viewer_ui.components`` to keep AST-extracted argument expressions
+    (e.g. f-strings like ``f"workflow.continue:{session_id}"``) safe to embed
+    in node labels.
+    """
+    text = (
+        text.replace('"', "'")
+        .replace("{", "(")
+        .replace("}", ")")
+        .replace("[", ".")
+        .replace("]", "")
+        .replace("'", "")
+    )
+    if len(text) > max_len:
+        text = text[: max_len - 3] + "..."
+    return text
+
+
 class MermaidGenerator:
     """
     Generator for Mermaid flowchart diagrams.
@@ -96,12 +120,12 @@ class MermaidGenerator:
             elif step_type == "wait_event":
                 # Event waiting
                 node_id = self._next_node_id()
-                event_type = step.get("event_type", "unknown")
+                event_type = escape_mermaid_label(step.get("event_type", "unknown"))
                 timeout = step.get("timeout")
 
                 label = f"wait_event:<br/>{event_type}"
                 if timeout:
-                    label += f"<br/>timeout: {timeout}s"
+                    label += f"<br/>timeout: {escape_mermaid_label(str(timeout))}s"
 
                 self.lines.append(f"    {node_id}{{{{{label}}}}}")
                 self.lines.append(f"    {current_id} --> {node_id}")

--- a/tests/test_mermaid_escape.py
+++ b/tests/test_mermaid_escape.py
@@ -1,0 +1,172 @@
+"""Regression tests for Mermaid label escaping.
+
+Covers issue #7: Edda viewer fails when an f-string is used as the
+``event_type`` argument of ``wait_event``. The AST analyzer extracts the
+unparsed source ``f'workflow.continue:{session_id}'`` which contains
+``{`` / ``}`` characters. Without escaping, those characters break the
+Mermaid hexagon node syntax (``id{{label}}``) and the chart fails to
+render.
+"""
+
+from edda.viewer_ui.components import HybridMermaidGenerator
+from edda.visualizer.ast_analyzer import WorkflowAnalyzer
+from edda.visualizer.mermaid_generator import MermaidGenerator, escape_mermaid_label
+
+
+class TestEscapeMermaidLabel:
+    """Direct tests for the ``escape_mermaid_label`` helper."""
+
+    def test_replaces_curly_braces(self):
+        assert escape_mermaid_label("foo{bar}baz") == "foo(bar)baz"
+
+    def test_replaces_brackets_and_quotes(self):
+        assert escape_mermaid_label('a["b"][c]') == "a.b.c"
+
+    def test_truncates_long_text(self):
+        text = "x" * 100
+        out = escape_mermaid_label(text, max_len=20)
+        assert len(out) == 20
+        assert out.endswith("...")
+
+    def test_preserves_simple_text(self):
+        assert escape_mermaid_label("workflow.continue") == "workflow.continue"
+
+    def test_handles_fstring_source(self):
+        # ast.unparse() of f"workflow.continue:{session_id}" produces this
+        unparsed = "f'workflow.continue:{session_id}'"
+        out = escape_mermaid_label(unparsed)
+        assert "{" not in out
+        assert "}" not in out
+
+
+class TestAstAnalyzerFstring:
+    """Confirm the AST analyzer returns an f-string source representation
+    (containing ``{`` and ``}``) for non-Constant ``event_type`` arguments.
+    This documents the input we have to escape downstream."""
+
+    def test_fstring_event_type_extracted_as_source(self):
+        source = '''
+@workflow
+async def fstring_workflow(ctx, session_id: str):
+    """Workflow that waits with an f-string event_type."""
+    await wait_event(ctx, event_type=f"workflow.continue:{session_id}")
+'''
+        workflows = WorkflowAnalyzer().analyze(source)
+        assert len(workflows) == 1
+        steps = workflows[0]["steps"]
+        wait_steps = [s for s in steps if s.get("type") == "wait_event"]
+        assert len(wait_steps) == 1
+
+        event_type = wait_steps[0]["event_type"]
+        # AST analyzer returns the source representation of the f-string,
+        # not the runtime-evaluated value.
+        assert "{" in event_type
+        assert "}" in event_type
+        assert "session_id" in event_type
+
+    def test_constant_event_type_extracted_directly(self):
+        source = '''
+@workflow
+async def const_workflow(ctx):
+    await wait_event(ctx, event_type="workflow.continue")
+'''
+        workflows = WorkflowAnalyzer().analyze(source)
+        wait_steps = [s for s in workflows[0]["steps"] if s.get("type") == "wait_event"]
+        assert wait_steps[0]["event_type"] == "workflow.continue"
+
+
+def _wait_event_label_chunks(mermaid: str) -> list[str]:
+    """Extract the label inside hexagon nodes ``id{{...}}`` for inspection."""
+    chunks: list[str] = []
+    for line in mermaid.splitlines():
+        stripped = line.strip()
+        # Hexagon syntax: <id>{{<label>}}
+        idx = stripped.find("{{")
+        end = stripped.rfind("}}")
+        if idx != -1 and end != -1 and end > idx:
+            chunks.append(stripped[idx + 2 : end])
+    return chunks
+
+
+class TestMermaidGeneratorWaitEvent:
+    """Verify ``MermaidGenerator`` (base) escapes f-string event_type."""
+
+    def test_fstring_event_type_does_not_break_mermaid(self):
+        workflow = {
+            "name": "fstring_workflow",
+            "steps": [
+                {
+                    "type": "wait_event",
+                    "event_type": "f'workflow.continue:{session_id}'",
+                    "timeout": None,
+                }
+            ],
+        }
+        mermaid = MermaidGenerator().generate(workflow)
+
+        # No curly braces should leak into the hexagon label region
+        for label in _wait_event_label_chunks(mermaid):
+            assert "{" not in label, f"unexpected {{ in label: {label!r}"
+            assert "}" not in label, f"unexpected }} in label: {label!r}"
+
+        # The recognizable identifier should still survive (read-only check)
+        assert "session_id" in mermaid
+
+    def test_normal_event_type_renders(self):
+        workflow = {
+            "name": "normal_workflow",
+            "steps": [
+                {
+                    "type": "wait_event",
+                    "event_type": "payment.completed",
+                    "timeout": 30,
+                }
+            ],
+        }
+        mermaid = MermaidGenerator().generate(workflow)
+        assert "wait_event:<br/>payment.completed" in mermaid
+        assert "timeout: 30s" in mermaid
+
+
+class TestHybridMermaidGeneratorWaitEvent:
+    """Verify ``HybridMermaidGenerator`` (viewer UI) also escapes."""
+
+    def test_fstring_event_type_does_not_break_mermaid(self):
+        workflow = {
+            "name": "fstring_workflow",
+            "steps": [
+                {
+                    "type": "wait_event",
+                    "event_type": "f'workflow.continue:{session_id}'",
+                    "timeout": None,
+                }
+            ],
+        }
+        gen = HybridMermaidGenerator(
+            instance_id="inst-1",
+            executed_activities=set(),
+        )
+        mermaid = gen.generate(workflow)
+
+        for label in _wait_event_label_chunks(mermaid):
+            assert "{" not in label, f"unexpected {{ in label: {label!r}"
+            assert "}" not in label, f"unexpected }} in label: {label!r}"
+
+        assert "session_id" in mermaid
+
+
+class TestEndToEndWaitEventEscape:
+    """Source code -> AST analyzer -> Mermaid (no broken syntax)."""
+
+    def test_fstring_workflow_source_to_mermaid_is_valid(self):
+        source = '''
+@workflow
+async def fstring_workflow(ctx, session_id: str):
+    await wait_event(ctx, event_type=f"workflow.continue:{session_id}")
+'''
+        workflows = WorkflowAnalyzer().analyze(source)
+        mermaid = MermaidGenerator().generate(workflows[0])
+
+        for label in _wait_event_label_chunks(mermaid):
+            assert "{" not in label
+            assert "}" not in label

--- a/tests/test_mermaid_escape.py
+++ b/tests/test_mermaid_escape.py
@@ -65,11 +65,11 @@ async def fstring_workflow(ctx, session_id: str):
         assert "session_id" in event_type
 
     def test_constant_event_type_extracted_directly(self):
-        source = '''
+        source = """
 @workflow
 async def const_workflow(ctx):
     await wait_event(ctx, event_type="workflow.continue")
-'''
+"""
         workflows = WorkflowAnalyzer().analyze(source)
         wait_steps = [s for s in workflows[0]["steps"] if s.get("type") == "wait_event"]
         assert wait_steps[0]["event_type"] == "workflow.continue"
@@ -181,11 +181,11 @@ class TestEndToEndWaitEventEscape:
     """Source code -> AST analyzer -> Mermaid (no broken syntax)."""
 
     def test_fstring_workflow_source_to_mermaid_is_valid(self):
-        source = '''
+        source = """
 @workflow
 async def fstring_workflow(ctx, session_id: str):
     await wait_event(ctx, event_type=f"workflow.continue:{session_id}")
-'''
+"""
         workflows = WorkflowAnalyzer().analyze(source)
         mermaid = MermaidGenerator().generate(workflows[0])
 

--- a/tests/test_mermaid_escape.py
+++ b/tests/test_mermaid_escape.py
@@ -127,6 +127,28 @@ class TestMermaidGeneratorWaitEvent:
         assert "wait_event:<br/>payment.completed" in mermaid
         assert "timeout: 30s" in mermaid
 
+    def test_hexagon_uses_quoted_form(self):
+        # Mermaid 11 rejects bare parens / colons in unquoted hexagon labels.
+        # The escape helper introduces parens (from { and }), so the hexagon
+        # MUST be emitted in quoted form id{{"..."}} or rendering breaks.
+        workflow = {
+            "name": "any_workflow",
+            "steps": [
+                {
+                    "type": "wait_event",
+                    "event_type": "f'workflow.continue:{session_id}'",
+                    "timeout": None,
+                }
+            ],
+        }
+        mermaid = MermaidGenerator().generate(workflow)
+        hexagon_lines = [
+            line for line in mermaid.splitlines() if "{{" in line and "wait_event" in line
+        ]
+        assert len(hexagon_lines) == 1
+        assert '{{"' in hexagon_lines[0]
+        assert '"}}' in hexagon_lines[0]
+
 
 class TestHybridMermaidGeneratorWaitEvent:
     """Verify ``HybridMermaidGenerator`` (viewer UI) also escapes."""


### PR DESCRIPTION
## What
1. Add `escape_mermaid_label()` helper that strips `{` / `}` from the f-string source returned by `ast.unparse()`. Apply to `wait_event` in both `MermaidGenerator` and `HybridMermaidGenerator`, and reuse at the existing condition / match-case escape sites.
2. Emit the wait_event hexagon in mermaid's quoted form `id{{"label"}}`.

## Why
The AST analyzer extracts source text for non-constant arguments, so `event_type=f"workflow.continue:{x}"` leaks literal `{` / `}` into the mermaid hexagon (`id{{label}}`) and breaks parsing. Replacing braces with `(` / `)` cleared the first issue, but mermaid 11 then rejected the bare parens; the quoted hexagon form accepts arbitrary text.

## Test plan
- [x] `uv run pytest tests/test_mermaid_escape.py tests/test_ast_analyzer.py` — 32 passed (12 new + 20 existing)
- [x] `uv run ruff check` / `uv run mypy` clean
- [x] Verified in the actual viewer: `wait_event` node now renders for an f-string `event_type` (mermaid 11.12.0)

Fixes #7.